### PR TITLE
Optional pip arguments

### DIFF
--- a/dockerfile_requirements/__init__.py
+++ b/dockerfile_requirements/__init__.py
@@ -28,10 +28,10 @@ def read_requirements(fname):
 
 
 ADD_REQUIREMENTS_MACRO = """
-{%- macro add_requirements(fname) -%}
+{%- macro add_requirements(fname, args="") -%}
 # Requirements populated from {{fname}}
 {% for requirement in read_requirements(fname) -%}
-RUN pip install "{{ requirement }}"
+RUN pip install "{{ requirement }}" {{ args }}
 {% endfor -%}
 {%- endmacro -%}
 """

--- a/dockerfile_requirements/__init__.py
+++ b/dockerfile_requirements/__init__.py
@@ -31,7 +31,7 @@ ADD_REQUIREMENTS_MACRO = """
 {%- macro add_requirements(fname, args="") -%}
 # Requirements populated from {{fname}}
 {% for requirement in read_requirements(fname) -%}
-RUN pip install "{{ requirement }}" {{ args }}
+RUN pip install {{ args }} "{{ requirement }}" 
 {% endfor -%}
 {%- endmacro -%}
 """

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(
     name='dockerfile-requirements',
     packages=['dockerfile_requirements'],
     platforms='any',
-    version='0.0.2',
+    version='0.0.3',
     description='Inlining requirements.txt files into Dockerfiles for better caching.',
     author='H. Chase Stevens',
     author_email='chase@chasestevens.com',


### PR DESCRIPTION
The library should have the capability to pass arguments such as `extra-index-url` into the macro so we can execute specific pip install commands.